### PR TITLE
Remove undefined bounds

### DIFF
--- a/src/L.Control.Heightgraph.js
+++ b/src/L.Control.Heightgraph.js
@@ -120,7 +120,6 @@ L.Control.Heightgraph = L.Control.extend({
             this._dragRectangleG.remove();
             this._dragRectangleG = null;
             this._dragRectangle = null;
-            this._map.fitBounds(bounds);
         }
     },
     /**


### PR DESCRIPTION
Fixes #47

The bounds haven't been defined anywhere. I guess the initial idea was to zoom back, when closing the HeightGraph? I removed the line for now