### PR TITLE
Updated the style

### DIFF
--- a/src/L.Control.Heightgraph.css
+++ b/src/L.Control.Heightgraph.css
@@ -1,5 +1,5 @@
 .heightgraph-container {
-    background-color: #FFF;
+    background-color: rgba(250,250,250,.8);
     border-radius: 10px;
     display: none;
     cursor: default;
@@ -36,8 +36,6 @@
 }
 
 .border-top {
-    stroke-width: 1;
-    stroke: #999;
     fill: none;
 }
 
@@ -52,7 +50,7 @@
 }
 
 .tick, .tick text {
-    fill: #999;
+    fill: #000;
     pointer-events: none;
 }
 
@@ -66,7 +64,6 @@
     fill: none;
     stroke-width: 2px;
     shape-rendering: crispEdges;
-    stroke: lightgrey;
     pointer-events: none;
 }
 
@@ -113,6 +110,10 @@
 .height-focus.circle {
     stroke: #FFF;
     stroke-width: 1px;
+}
+
+.mouse-height-box-text{
+    font-size: 12px;
 }
 
 .grid .tick {

--- a/src/L.Control.Heightgraph.js
+++ b/src/L.Control.Heightgraph.js
@@ -406,11 +406,11 @@ L.Control.Heightgraph = L.Control.extend({
         this._mouseHeightFocusLabelTextElev.attr("x", layerpoint.x + 5)
             .attr("y", normalizedY + 12)
             .text(height + " m")
-            .attr("class", "tspan");
+            .attr("class", "tspan mouse-height-box-text");
         this._mouseHeightFocusLabelTextType.attr("x", layerpoint.x + 5)
             .attr("y", normalizedY + 24)
             .text(type)
-            .attr("class", "tspan");
+            .attr("class", "tspan mouse-height-box-text");
         var maxWidth = this._dynamicBoxSize('text.tspan')[1];
         // box size should change for profile none (no type)
         var maxHeight = (type === "") ? 12 + 6 : 2 * 12 + 6;
@@ -693,6 +693,7 @@ L.Control.Heightgraph = L.Control.extend({
             .attr('class', 'x axis')
             .call(this._xAxis);
         this._svg.append('g')
+            .attr("transform", "translate(-2,0)")
             .attr('class', 'y axis')
             .call(this._yAxis);
     },


### PR DESCRIPTION
Fixes #60 

I updated the style a bit. I personally like it better that way :). But these changes are always quite opinionated.

That's how the style looks right now:
![Screenshot from 2019-07-17 17-24-47](https://user-images.githubusercontent.com/1553525/61388486-39e0e680-a8b8-11e9-8201-70f30d785ba3.png)

What I changed:
- I added a background transparency
- I removed the stroke for the top border, as this can look a bit ugly for long routes (~ >300km), depending on the width of the graph
- The axis and labels are now black to make it easier to read
- I fixed the font-size for mouse hover box. Before the font-size would fallback to the default font size of the document and there was no easy way to fix it.

WDYT @TimMcCauley should we merge this? Especially the black axis and background transparency are a bit opinionated. I could remove these changes from the PR.

