### PR TITLE
mappings: undefined not possible in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
          <script src="https://d3js.org/d3-interpolate.v1.min.js"></script>
          <script src="https://d3js.org/d3-path.v1.min.js"></script>
          <script src="https://d3js.org/d3-scale-chromatic.v1.min.js"></script>
+         <script src="https://d3js.org/d3-collection.v1.min.js"></script>
          <script type="text/javascript" src="example_data.js"></script>
          <script type="text/javascript" src="example_mappings.js"></script>
          <script type="text/javascript" src="src/L.Control.Heightgraph.js"></script>


### PR DESCRIPTION
d3-collection seems to be missing if L.control.heightgraph is initialised with {mappings: undefined}. Although it is not required in this example, it may help users to use their own GeoJSON data without the need to define matching mappings.