### PR TITLE
Allow specifying opacity for color mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,11 +188,13 @@ Example:
 colorMappings.Steepness = {
     '3': {
         text: '1-3%',
-        color: '#F29898'
+        color: '#F29898',
+        opacity: 0.8
     },
     '0': {
         text: '4-6%',
         color: '#E07575'
+        /* opacity defaults to 1.0 */
     }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -188,13 +188,11 @@ Example:
 colorMappings.Steepness = {
     '3': {
         text: '1-3%',
-        color: '#F29898',
-        opacity: 0.8
+        color: '#F29898'
     },
     '0': {
         text: '4-6%',
         color: '#E07575'
-        /* opacity defaults to 1.0 */
     }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ highlightStyle = {
  }
 ```
 
+### graphStyle
+Allows customizing the style of the height graph.
+You may specify the [<path> element presentation attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path) in the form of a JavaScript object.
+Note that in case of conflict the `mappings` attributes take precedence over the `graphStyle` attributes.
+
+default: `graphStyle: {}`
+
+Example:
+```javascript
+graphStyle = {
+    opacity: 0.8,
+    'fill-opacity': 0.5,
+    'stroke-width': '2px'
+};
+```
+
 ### translation
 You can change the labels of the heightgraph info field by passing translations
 for `distance`, `elevation`, `segment_length`, `type` and `legend`.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "concurrently": "^2.0.0",
     "connect-modrewrite": "^0.10.2",
     "d3": "^5.16.0",
+    "d3-selection-multi": "^1.0.1",
     "es-dev-server": "^1.55.1",
     "jasmine-core": "^3.5.0",
     "karma": "^4.4.1",

--- a/src/L.Control.Heightgraph.js
+++ b/src/L.Control.Heightgraph.js
@@ -307,7 +307,7 @@ import {
                     // save attribute types related to blocks
                     const attributeType = data[y].features[i].properties.attributeType
                     // check if mappings are defined, otherwise random colors
-                    let text, color
+                    let text, color, opacity = 1.0
                     if (this._mappings === undefined) {
                         if (attributeType in usedColors) {
                             text = attributeType;
@@ -320,9 +320,10 @@ import {
                     } else {
                         text = this._mappings[data[y].properties.summary][attributeType].text;
                         color = this._mappings[data[y].properties.summary][attributeType].color;
+                        opacity = this._mappings[data[y].properties.summary][attributeType].opacity;
                     }
                     const attribute = {
-                        type: attributeType, text: text, color: color
+                        type: attributeType, text: text, color: color, opacity: opacity
                     }
                     this._profile.blocks[y].attributes.push(attribute);
                     // add to legend
@@ -717,6 +718,7 @@ import {
          */
         _appendAreas(block, idx, eleIdx) {
             const c = this._profile.blocks[idx].attributes[eleIdx].color
+            const opacity = this._profile.blocks[idx].attributes[eleIdx].opacity
             const self = this
             const area = this._area = d3Area().x(d => {
                 const xDiagonalCoordinate = self._x(d.position)
@@ -729,6 +731,7 @@ import {
                 .attr("d", this._area)
                 .attr("stroke", c)
                 .style("fill", c)
+                .style("opacity", opacity)
                 .style("pointer-events", "none");
         },
         // grid lines in x axis function

--- a/src/L.Control.Heightgraph.js
+++ b/src/L.Control.Heightgraph.js
@@ -307,7 +307,7 @@ import {
                     // save attribute types related to blocks
                     const attributeType = data[y].features[i].properties.attributeType
                     // check if mappings are defined, otherwise random colors
-                    let text, color, opacity = 1.0
+                    let text, color
                     if (this._mappings === undefined) {
                         if (attributeType in usedColors) {
                             text = attributeType;
@@ -320,10 +320,9 @@ import {
                     } else {
                         text = this._mappings[data[y].properties.summary][attributeType].text;
                         color = this._mappings[data[y].properties.summary][attributeType].color;
-                        opacity = this._mappings[data[y].properties.summary][attributeType].opacity;
                     }
                     const attribute = {
-                        type: attributeType, text: text, color: color, opacity: opacity
+                        type: attributeType, text: text, color: color
                     }
                     this._profile.blocks[y].attributes.push(attribute);
                     // add to legend
@@ -718,7 +717,6 @@ import {
          */
         _appendAreas(block, idx, eleIdx) {
             const c = this._profile.blocks[idx].attributes[eleIdx].color
-            const opacity = this._profile.blocks[idx].attributes[eleIdx].opacity
             const self = this
             const area = this._area = d3Area().x(d => {
                 const xDiagonalCoordinate = self._x(d.position)
@@ -731,7 +729,6 @@ import {
                 .attr("d", this._area)
                 .attr("stroke", c)
                 .style("fill", c)
-                .style("opacity", opacity)
                 .style("pointer-events", "none");
         },
         // grid lines in x axis function

--- a/src/L.Control.Heightgraph.js
+++ b/src/L.Control.Heightgraph.js
@@ -1,4 +1,5 @@
 import {select, selectAll, mouse} from 'd3-selection'
+import 'd3-selection-multi'
 import {scaleOrdinal,scaleLinear} from 'd3-scale'
 import {quantile as d3Quantile, min as d3Min, max as d3Max, bisector} from 'd3-array'
 import {drag} from 'd3-drag'
@@ -50,7 +51,8 @@ import {
             expandCallback: undefined,
             xTicks: undefined,
             yTicks: undefined,
-            highlightStyle: undefined
+            highlightStyle: undefined,
+            graphStyle: undefined
         },
         _defaultTranslation: {
             distance: "Distance",
@@ -68,6 +70,7 @@ import {
             this._svgHeight = this._height - this._margin.top - this._margin.bottom;
             this._selectedOption = 0
             this._highlightStyle = this.options.highlightStyle || {color: 'red'}
+            this._graphStyle = this.options.graphStyle || {}
         },
         onAdd(map) {
             let container = this._container = L.DomUtil.create("div", "heightgraph")
@@ -728,6 +731,7 @@ import {
             this._areapath.datum(block)
                 .attr("d", this._area)
                 .attr("stroke", c)
+                .styles(this._graphStyle)
                 .style("fill", c)
                 .style("pointer-events", "none");
         },


### PR DESCRIPTION
This allows visually appealing (in my eyes) graphs like these without having to resort to CSS hacks:
![opacity](https://user-images.githubusercontent.com/29906522/86135673-bd253780-bb1d-11ea-9730-41dd3b9cba16.png)
