### PR TITLE
resizable example: Add minimum sizes

### DIFF
--- a/example/example-resizable.js
+++ b/example/example-resizable.js
@@ -30,6 +30,8 @@ map.addLayer(openstreetmap).fitBounds(bounds)
 
 $('.heightgraph').resizable({
     handles: 'w, n, nw',
+    minWidth: 380,
+    minHeight: 140,
     stop: function(event, ui) {
         // Remove the size/position of the UI element (.heightgraph .leaflet-control) because
         // it should be sized dynamically based on its contents. Giving it a fixed size causes


### PR DESCRIPTION
This is a tiny change to address the "set reasonable minimum value for width/height" issue mentioned in https://github.com/GIScience/Leaflet.Heightgraph/pull/84.